### PR TITLE
ci(workflow): configure git user identity for automated version bumps

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Install Commitizen
         run: pip install commitizen
 
+      - name: Configure Git User
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Run Commitizen bump
         run: cz bump --yes
 


### PR DESCRIPTION
- Add `git config` steps to the GitHub Actions workflow to set the user name and email to `github-actions[bot]`. 
- This fixes the "Author identity unknown" error that prevented `cz bump` from creating the release commit